### PR TITLE
add token_transfers_v2 domain to batch job

### DIFF
--- a/ethereumetl/streaming/item_exporter_creator.py
+++ b/ethereumetl/streaming/item_exporter_creator.py
@@ -63,6 +63,7 @@ def create_item_exporter(output, testnet):
                 'transaction': output + '.transactions',
                 'log': output + '.logs',
                 'token_transfer': output + '.token_transfers',
+                'token_transfer_v2': output + '.token_transfers_v2',
                 'trace': output + '.traces',
                 'contract': output + '.contracts',
                 'token': output + '.tokens',
@@ -78,7 +79,7 @@ def create_item_exporter(output, testnet):
         from blockchainetl.jobs.exporters.converters.unix_timestamp_item_converter import UnixTimestampItemConverter
         from blockchainetl.jobs.exporters.converters.int_to_decimal_item_converter import IntToDecimalItemConverter
         from blockchainetl.jobs.exporters.converters.list_field_item_converter import ListFieldItemConverter
-        from ethereumetl.streaming.postgres_tables import BLOCKS, TRANSACTIONS, LOGS, TOKEN_TRANSFERS, TRACES, TOKENS, CONTRACTS
+        from ethereumetl.streaming.postgres_tables import BLOCKS, TRANSACTIONS, LOGS, TOKEN_TRANSFERS, TOKEN_TRANSFERS_V2, TRACES, TOKENS, CONTRACTS
 
         item_exporter = PostgresItemExporter(
             output, item_type_to_insert_stmt_mapping={
@@ -86,6 +87,7 @@ def create_item_exporter(output, testnet):
                 'transaction': create_insert_statement_for_table(TRANSACTIONS),
                 'log': create_insert_statement_for_table(LOGS),
                 'token_transfer': create_insert_statement_for_table(TOKEN_TRANSFERS),
+                'token_transfer_v2': create_insert_statement_for_table(TOKEN_TRANSFERS_V2),
                 'trace': create_insert_statement_for_table(TRACES),
                 'token': create_insert_statement_for_table(TOKENS),
                 'contract': create_insert_statement_for_table(CONTRACTS),

--- a/ethereumetl/streaming/postgres_tables.py
+++ b/ethereumetl/streaming/postgres_tables.py
@@ -105,6 +105,21 @@ TOKEN_TRANSFERS = Table(
     Column('block_hash', String),
 )
 
+TOKEN_TRANSFERS_V2 = Table(
+    'token_transfers_v2', metadata,
+    Column('contract_address', String),
+    Column('from_address', String),
+    Column('to_address', String),
+    Column('token_type', String),
+    Column('token_id', String),
+    Column('amount', Numeric(78)),
+    Column('transaction_hash', String, primary_key=True),
+    Column('log_index', BigInteger, primary_key=True),
+    Column('block_timestamp', TIMESTAMP),
+    Column('block_number', BigInteger),
+    Column('block_hash', String),
+)
+
 TRACES = Table(
     'traces', metadata,
     Column('transaction_hash', String),

--- a/schemas/aws/parquet/parquet_token_transfers_v2.sql
+++ b/schemas/aws/parquet/parquet_token_transfers_v2.sql
@@ -13,4 +13,4 @@ PARTITIONED BY (start_block BIGINT, end_block BIGINT)
 STORED AS PARQUET
 LOCATION 's3://<your_bucket>/ethereumetl/parquet/token_transfers_v2';
 
-MSCK REPAIR TABLE parquet_token_transfers;
+MSCK REPAIR TABLE parquet_token_transfers_v2;

--- a/schemas/aws/parquet/parquet_token_transfers_v2.sql
+++ b/schemas/aws/parquet/parquet_token_transfers_v2.sql
@@ -1,0 +1,16 @@
+CREATE EXTERNAL TABLE IF NOT EXISTS parquet_token_transfers_v2 (
+    contract_address STRING,
+    from_address STRING,
+    to_address STRING,
+    amount STRING,
+    token_type STRING,
+    token_ids STRING,
+    transaction_hash STRING,
+    log_index BIGINT,
+    block_number BIGINT
+)
+PARTITIONED BY (start_block BIGINT, end_block BIGINT)
+STORED AS PARQUET
+LOCATION 's3://<your_bucket>/ethereumetl/parquet/token_transfers_v2';
+
+MSCK REPAIR TABLE parquet_token_transfers;

--- a/schemas/aws/token_transfers_v2.sql
+++ b/schemas/aws/token_transfers_v2.sql
@@ -1,0 +1,25 @@
+CREATE EXTERNAL TABLE IF NOT EXISTS token_transfers_v2 (
+    contract_address STRING,
+    from_address STRING,
+    to_address STRING,
+    amount STRING,
+    token_type STRING,
+    token_ids STRING,
+    transaction_hash STRING,
+    log_index BIGINT,
+    block_number BIGINT
+)
+PARTITIONED BY (start_block BIGINT, end_block BIGINT)
+ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe'
+WITH SERDEPROPERTIES (
+    'serialization.format' = ',',
+    'field.delim' = ',',
+    'escape.delim' = '\\'
+)
+STORED AS TEXTFILE
+LOCATION 's3://<your_bucket>/ethereumetl/export/token_transfers_v2'
+TBLPROPERTIES (
+  'skip.header.line.count' = '1'
+);
+
+MSCK REPAIR TABLE token_transfers;

--- a/schemas/aws/token_transfers_v2.sql
+++ b/schemas/aws/token_transfers_v2.sql
@@ -22,4 +22,4 @@ TBLPROPERTIES (
   'skip.header.line.count' = '1'
 );
 
-MSCK REPAIR TABLE token_transfers;
+MSCK REPAIR TABLE token_transfers_v2;


### PR DESCRIPTION
## What is the change?
support token_transfers_v2 export in batch job

## Why do we need it?
- consistency with streaming data
- Need this data for corrections, backfills and analytics

## Test plan
Will need to update the submodule in `chain-etl` repo and then upload the new DAG folder for changes to be reflected