### PR TITLE
use psycopg2

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -210,8 +210,8 @@ e.g. `-e block,transaction,log,token_transfer,trace,contract,token`.
 - Use `--output` option to specify the Google Pub/Sub topic, Postgres database or GCS bucket where to publish blockchain data, 
     - For Google PubSub: `--output=projects/<your-project>/topics/crypto_ethereum`. 
     Data will be pushed to `projects/<your-project>/topics/crypto_ethereum.blocks`, `projects/<your-project>/topics/crypto_ethereum.transactions` etc. topics.
-    - For Postgres: `--output=postgresql+pg8000://<user>:<password>@<host>:<port>/<database_name>`, 
-    e.g. `--output=postgresql+pg8000://postgres:admin@127.0.0.1:5432/ethereum`.
+    - For Postgres: `--output=postgresql://<user>:<password>@<host>:<port>/<database_name>`, 
+    e.g. `--output=postgresql://postgres:admin@127.0.0.1:5432/ethereum`.
     - For GCS:  `--output=gs://<bucket_name>`. Make sure to install and initialize `gcloud` cli.
     - For Kafka:  `--output=kafka/<host>:<port>`, e.g. `--output=kafka/127.0.0.1:9092`
     - Those output types can be combined with a comma e.g. `--output=gs://<bucket_name>,projects/<your-project>/topics/crypto_ethereum`
@@ -238,7 +238,7 @@ Stream blockchain data continually to Google Pub/Sub:
 Stream blockchain data to a Postgres database:
 
 ```bash
-ethereumetl stream --start-block 500000 --output postgresql+pg8000://<user>:<password>@<host>:5432/<database>
+ethereumetl stream --start-block 500000 --output postgresql://<user>:<password>@<host>:5432/<database>
 ```
 
 The [schema](https://github.com/blockchain-etl/ethereum-etl-postgres/tree/master/schema) 

--- a/ethereumetl/cli/stream.py
+++ b/ethereumetl/cli/stream.py
@@ -39,7 +39,7 @@ from ethereumetl.thread_local_proxy import ThreadLocalProxy
                    'file://$HOME/Library/Ethereum/geth.ipc or https://mainnet.infura.io')
 @click.option('-o', '--output', type=str,
               help='Either Google PubSub topic path e.g. projects/your-project/topics/crypto_ethereum; '
-                   'or Postgres connection url e.g. postgresql+pg8000://postgres:admin@127.0.0.1:5432/ethereum; '
+                   'or Postgres connection url e.g. postgresql://postgres:admin@127.0.0.1:5432/ethereum; '
                    'or GCS bucket e.g. gs://your-bucket-name; '
                    'or kafka, output name and connection host:port e.g. kafka/127.0.0.1:9092 '
                    'If not specified will print to console')

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
             'google-cloud-storage==1.33.0',
             'kafka-python==2.0.2',
             'sqlalchemy==1.4',
-            'pg8000==1.16.6',
+            'psycopg2==2.9.3',
             # This library is a dependency for google-cloud-pubsub, starting from 0.3.22 it requires Rust,
             # that's why  we lock the version here
             'libcst==0.3.21'


### PR DESCRIPTION
pg8000 [does not support ssl arguments](https://github.com/sqlalchemy/sqlalchemy/issues/4146) through the database url similar to the other adapters like we use in rust. We need SSL to connect to the cockroach cluster from the kafka producer. Switching to `psycopg2` database adapter which allows us to use `sslmode=require` in the database url



