### PR TITLE
add sqlalchemy-cockroachdb

### DIFF
--- a/ethereumetl/streaming/item_exporter_creator.py
+++ b/ethereumetl/streaming/item_exporter_creator.py
@@ -130,7 +130,7 @@ def determine_item_exporter_type(output):
         return ItemExporterType.PUBSUB
     if output is not None and output.startswith('kafka'):
         return ItemExporterType.KAFKA
-    elif output is not None and output.startswith('postgresql'):
+    elif output is not None and (output.startswith('postgresql') or output.startswith('cockroachdb')):
         return ItemExporterType.POSTGRES
     elif output is not None and output.startswith('gs://'):
         return ItemExporterType.GCS

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(
             'kafka-python==2.0.2',
             'sqlalchemy==1.4',
             'psycopg2==2.9.3',
+            'sqlalchemy-cockroachdb==1.4.3',
             # This library is a dependency for google-cloud-pubsub, starting from 0.3.22 it requires Rust,
             # that's why  we lock the version here
             'libcst==0.3.21'


### PR DESCRIPTION
cockroach recommends using `sqlalchemy-cockroachdb` and uris starting with `cockroachdb` 

https://www.cockroachlabs.com/docs/v22.1/build-a-python-app-with-cockroachdb-sqlalchemy

Seeing the following error with current adapter and `postgresql://` uri

```
AssertionError: Could not determine version from string 'CockroachDB CCL v22.1.1 (x86_64-pc-linux-gnu, built 2022/06/06 16:38:56, go1.17.6)'
```