### PR TITLE
Revert "change table name for token_transfer "

### DIFF
--- a/ethereumetl/streaming/postgres_tables.py
+++ b/ethereumetl/streaming/postgres_tables.py
@@ -96,7 +96,7 @@ LOGS = Table(
 )
 
 TOKEN_TRANSFERS = Table(
-    'token_transfers_legacy', metadata,
+    'token_transfers', metadata,
     Column('token_address', String),
     Column('from_address', String),
     Column('to_address', String),
@@ -110,7 +110,7 @@ TOKEN_TRANSFERS = Table(
 )
 
 TOKEN_TRANSFERS_V2 = Table(
-    'token_transfers', metadata,
+    'token_transfers_v2', metadata,
     Column('contract_address', String),
     Column('from_address', String),
     Column('to_address', String),


### PR DESCRIPTION
Reverts BitskiCo/ethereum-etl#19

Reverting this as its not a good addition to the `chain-etl` repo. Will go over commit history and clean up more of these to keep bitski fork close to blockchain-etl