### PR TITLE
add token_id to primary key for token_transfer_v2

### DIFF
--- a/ethereumetl/streaming/postgres_tables.py
+++ b/ethereumetl/streaming/postgres_tables.py
@@ -115,7 +115,7 @@ TOKEN_TRANSFERS_V2 = Table(
     Column('from_address', String),
     Column('to_address', String),
     Column('token_type', String),
-    Column('token_id', String),
+    Column('token_id', String, primary_key=True),
     Column('amount', Numeric(78)),
     Column('transaction_hash', String, primary_key=True),
     Column('log_index', BigInteger, primary_key=True),


### PR DESCRIPTION
ERC-1155 batch transfers will have a `token_transfer_v2` record per token_id with the same log index and transaction hash. So, token_id also needs to be part of the primary key