### PR TITLE
fix item exporter for token_transfer_v2

### DIFF
--- a/ethereumetl/jobs/exporters/token_transfers_v2_item_exporter.py
+++ b/ethereumetl/jobs/exporters/token_transfers_v2_item_exporter.py
@@ -7,7 +7,7 @@ FIELDS_TO_EXPORT = [
     'to_address',
     'amount',
     'token_type'
-    'token_ids'
+    'token_id'
     'transaction_hash',
     'log_index',
     'block_number',
@@ -18,10 +18,10 @@ FIELDS_TO_EXPORT = [
 def token_transfers_v2_item_exporter(token_transfer_output, converters=()):
     return CompositeItemExporter(
         filename_mapping={
-            'token_transfer': token_transfer_output
+            'token_transfer_v2': token_transfer_output
         },
         field_mapping={
-            'token_transfer': FIELDS_TO_EXPORT
+            'token_transfer_v2': FIELDS_TO_EXPORT
         },
         converters=converters
     )

--- a/schemas/aws/token_transfers_v2.sql
+++ b/schemas/aws/token_transfers_v2.sql
@@ -4,7 +4,7 @@ CREATE EXTERNAL TABLE IF NOT EXISTS token_transfers_v2 (
     to_address STRING,
     amount STRING,
     token_type STRING,
-    token_ids STRING,
+    token_id STRING,
     transaction_hash STRING,
     log_index BIGINT,
     block_number BIGINT

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ long_description = read('README.md') if os.path.isfile("README.md") else ""
 
 setup(
     name='ethereum-etl-bitski-patched',
-    version='2.0.3',
+    version='2.1.1',
     author='Evgeny Medvedev',
     author_email='evge.medvedev@gmail.com',
     description='Tools for exporting Ethereum blockchain data to CSV or JSON',
@@ -36,7 +36,6 @@ setup(
         'eth-abi==2.1.1',
         # TODO: This has to be removed when "ModuleNotFoundError: No module named 'eth_utils.toolz'" is fixed at eth-abi
         'python-dateutil>=2.8.0,<3',
-        'click==8.0.4',
         'ethereum-dasm==0.1.4',
         'base58',
         'requests'


### PR DESCRIPTION
- fix file name mapping for `token_transfer_v2`
- Loosen constraint on `click` to remove version conflict with new dependencies in [ethereum-etl-airflow package](https://github.com/BitskiCo/ethereum-etl-airflow/blob/develop/dags/requirements.txt)