### PR TITLE
fix token_transfers_v2 batch extract and export

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ Export ERC20 and ERC721 transfers ([Schema](docs/schema.md#token_transferscsv), 
 --provider-uri file://$HOME/Library/Ethereum/geth.ipc --output token_transfers.csv
 ```
 
+Export ERC20, ERC721 and ERC1155 transfers ([Schema](docs/schema.md#token_transfers_v2csv), [Reference](docs/commands.md##export_token_transfers)):
+
+```bash
+> ethereumetl export_token_transfers_v2 --start-block 0 --end-block 500000 \
+--provider-uri file://$HOME/Library/Ethereum/geth.ipc --output token_transfers.csv
+```
+
+
 Export traces ([Schema](docs/schema.md#tracescsv), [Reference](docs/commands.md#export_traces)):
 
 ```bash

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -63,6 +63,27 @@ You can tune `--batch-size`, `--max-workers` for performance.
 
 [Token transfers schema](schema.md#token_transferscsv).
 
+#### export_token_transfers_v2
+
+Same as anove but supports ERC1155 batch transfers
+
+```bash
+> ethereumetl export_token_transfers_v2 --start-block 0 --end-block 500000 \
+--provider-uri file://$HOME/Library/Ethereum/geth.ipc --batch-size 100 --output token_transfers_v2.csv
+```
+
+Include `--tokens <token1> --tokens <token2>` to filter only certain tokens, e.g.
+
+```bash
+> ethereumetl export_token_transfers_v2 --start-block 0 --end-block 500000 \
+--provider-uri file://$HOME/Library/Ethereum/geth.ipc --output token_transfers_v2.csv \
+--tokens 0x1F573D6Fb3F13d689FF844B4cE37794d79a7FF1C --tokens 0x80fB784B7eD66730e8b1DBd9820aFD29931aab03
+```
+
+You can tune `--batch-size`, `--max-workers` for performance.
+
+[Token transfers v2 schema](schema.md#token_transfers_v2csv).
+
 #### export_receipts_and_logs
 
 First extract transaction hashes from `transactions.csv`

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -20,6 +20,13 @@ Export ERC20 and ERC721 transfers:
 --provider-uri file://$HOME/Library/Ethereum/geth.ipc --output token_transfers.csv
 ```
 
+Export ERC20, ERC721 and ERC1155 transfers:
+
+```bash
+> ethereumetl export_token_transfers_v2 --start-block 0 --end-block 500000 \
+--provider-uri file://$HOME/Library/Ethereum/geth.ipc --output token_transfers_v2.csv
+```
+
 Export traces:
 
 ```bash

--- a/ethereumetl/cli/__init__.py
+++ b/ethereumetl/cli/__init__.py
@@ -32,6 +32,7 @@ from ethereumetl.cli.export_geth_traces import export_geth_traces
 from ethereumetl.cli.export_origin import export_origin
 from ethereumetl.cli.export_receipts_and_logs import export_receipts_and_logs
 from ethereumetl.cli.export_token_transfers import export_token_transfers
+from ethereumetl.cli.export_token_transfers_v2 import export_token_transfers_v2
 from ethereumetl.cli.export_tokens import export_tokens
 from ethereumetl.cli.export_traces import export_traces
 from ethereumetl.cli.extract_contracts import extract_contracts
@@ -61,6 +62,7 @@ cli.add_command(export_blocks_and_transactions, "export_blocks_and_transactions"
 cli.add_command(export_origin, "export_origin")
 cli.add_command(export_receipts_and_logs, "export_receipts_and_logs")
 cli.add_command(export_token_transfers, "export_token_transfers")
+cli.add_command(export_token_transfers_v2, "export_token_transfers_v2")
 cli.add_command(extract_token_transfers, "extract_token_transfers")
 cli.add_command(extract_token_transfers_v2, "extract_token_transfers_v2")
 cli.add_command(export_contracts, "export_contracts")

--- a/ethereumetl/cli/export_token_transfers_v2.py
+++ b/ethereumetl/cli/export_token_transfers_v2.py
@@ -1,32 +1,8 @@
-# MIT License
-#
-# Copyright (c) 2018 Evgeny Medvedev, evge.medvedev@gmail.com
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
-
-
 import click
 
 from ethereumetl.web3_utils import build_web3
 
-from ethereumetl.jobs.export_token_transfers_job import ExportTokenTransfersJob
-from ethereumetl.jobs.exporters.token_transfers_item_exporter import token_transfers_item_exporter
+from ethereumetl.jobs.export_token_transfers_job_v2 import ExportTokenTransfersJobV2
 from ethereumetl.jobs.exporters.token_transfers_v2_item_exporter import token_transfers_v2_item_exporter
 from blockchainetl.logging_utils import logging_basic_config
 from ethereumetl.providers.auto import get_provider_from_uri
@@ -44,14 +20,14 @@ logging_basic_config()
 @click.option('-p', '--provider-uri', required=True, type=str,
               help='The URI of the web3 provider e.g. file://$HOME/Library/Ethereum/geth.ipc or http://localhost:8545/')
 @click.option('-t', '--tokens', default=None, show_default=True, type=str, multiple=True, help='The list of token addresses to filter by.')
-def export_token_transfers(start_block, end_block, batch_size, output, max_workers, provider_uri, tokens):
-    """Exports ERC20/ERC721 transfers."""
-    job = ExportTokenTransfersJob(
+def export_token_transfers_v2(start_block, end_block, batch_size, output, max_workers, provider_uri, tokens):
+    """Exports ERC20/ERC721/ERC1155 transfers."""
+    job = ExportTokenTransfersJobV2(
         start_block=start_block,
         end_block=end_block,
         batch_size=batch_size,
         web3=ThreadLocalProxy(lambda: build_web3(get_provider_from_uri(provider_uri))),
-        token_transfers_exporter=token_transfers_item_exporter(output),
+        token_transfers_v2_exporter=token_transfers_v2_item_exporter(output),
         max_workers=max_workers,
         tokens=tokens)
     job.run()

--- a/ethereumetl/cli/extract_token_transfers.py
+++ b/ethereumetl/cli/extract_token_transfers.py
@@ -28,7 +28,6 @@ import json
 from blockchainetl.file_utils import smart_open
 from blockchainetl.jobs.exporters.converters.int_to_string_item_converter import IntToStringItemConverter
 from ethereumetl.jobs.exporters.token_transfers_item_exporter import token_transfers_item_exporter
-from ethereumetl.jobs.exporters.token_transfers_v2_item_exporter import token_transfers_v2_item_exporter
 from ethereumetl.jobs.extract_token_transfers_job import ExtractTokenTransfersJob
 from blockchainetl.logging_utils import logging_basic_config
 
@@ -53,7 +52,6 @@ def extract_token_transfers(logs, batch_size, output, max_workers, values_as_str
             logs_iterable=logs_reader,
             batch_size=batch_size,
             max_workers=max_workers,
-            token_transfer_item_exporter=token_transfers_item_exporter(output, converters=converters),
-            token_transfer_v2_item_exporter=token_transfers_v2_item_exporter(output, converters=converters))
+            token_transfer_item_exporter=token_transfers_item_exporter(output, converters=converters))
 
         job.run()

--- a/ethereumetl/jobs/export_token_transfers_job_v2.py
+++ b/ethereumetl/jobs/export_token_transfers_job_v2.py
@@ -1,0 +1,72 @@
+from ethereumetl.executors.batch_work_executor import BatchWorkExecutor
+from blockchainetl.jobs.base_job import BaseJob
+from ethereumetl.mappers.token_transfer_v2_mapper import EthTokenTransferV2Mapper
+from ethereumetl.mappers.receipt_log_mapper import EthReceiptLogMapper
+from ethereumetl.service.token_transfer_v2_extractor import EthTokenTransferV2Extractor, TRANSFER_EVENT_TOPICS
+from ethereumetl.utils import validate_range
+
+
+class ExportTokenTransfersJobV2(BaseJob):
+    def __init__(
+            self,
+            start_block,
+            end_block,
+            batch_size,
+            web3,
+            token_transfers_v2_exporter,
+            max_workers,
+            tokens=None):
+        validate_range(start_block, end_block)
+        self.start_block = start_block
+        self.end_block = end_block
+
+        self.web3 = web3
+        self.tokens = tokens
+
+        self.token_transfers_v2_exporter = token_transfers_v2_exporter
+
+        self.batch_work_executor = BatchWorkExecutor(batch_size, max_workers)
+
+        self.receipt_log_mapper = EthReceiptLogMapper()
+        
+        self.token_transfer_v2_mapper = EthTokenTransferV2Mapper()
+
+        self.token_transfer_v2_extractor = EthTokenTransferV2Extractor()
+
+    def _start(self):
+        self.token_transfers_v2_exporter.open()
+
+    def _export(self):
+        self.batch_work_executor.execute(
+            range(self.start_block, self.end_block + 1),
+            self._export_batch,
+            total_items=self.end_block - self.start_block + 1
+        )
+
+    def _export_batch(self, block_number_batch):
+        assert len(block_number_batch) > 0
+        # https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_getfilterlogs
+        filter_params = {
+            'fromBlock': block_number_batch[0],
+            'toBlock': block_number_batch[-1],
+            'topics': TRANSFER_EVENT_TOPICS
+        }
+
+        if self.tokens is not None and len(self.tokens) > 0:
+            filter_params['address'] = self.tokens
+
+        event_filter = self.web3.eth.filter(filter_params)
+        events = event_filter.get_all_entries()
+        for event in events:
+            log = self.receipt_log_mapper.web3_dict_to_receipt_log(event)
+            
+            token_transfers_list_v2 = self.token_transfer_v2_extractor.extract_transfer_from_log(log)
+            if token_transfers_list_v2 is not None:
+                for token_transfer_v2 in token_transfers_list_v2:
+                    self.token_transfers_v2_exporter.export_item(self.token_transfer_v2_mapper.token_transfer_to_dict(token_transfer_v2))
+
+        self.web3.eth.uninstallFilter(event_filter.filter_id)
+
+    def _end(self):
+        self.batch_work_executor.shutdown()
+        self.token_transfers_v2_exporter.close()

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ long_description = read('README.md') if os.path.isfile("README.md") else ""
 
 setup(
     name='ethereum-etl-bitski-patched',
-    version='2.1.2',
+    version='2.1.3',
     author='Evgeny Medvedev',
     author_email='evge.medvedev@gmail.com',
     description='Tools for exporting Ethereum blockchain data to CSV or JSON',

--- a/tests/ethereumetl/job/test_export_token_transfers_job.py
+++ b/tests/ethereumetl/job/test_export_token_transfers_job.py
@@ -27,7 +27,6 @@ from ethereumetl.web3_utils import build_web3
 import tests.resources
 from ethereumetl.jobs.export_token_transfers_job import ExportTokenTransfersJob
 from ethereumetl.jobs.exporters.token_transfers_item_exporter import token_transfers_item_exporter
-from ethereumetl.jobs.exporters.token_transfers_v2_item_exporter import token_transfers_v2_item_exporter
 from ethereumetl.thread_local_proxy import ThreadLocalProxy
 from tests.ethereumetl.job.helpers import get_web3_provider
 from tests.helpers import compare_lines_ignore_order, read_file
@@ -52,7 +51,6 @@ def test_export_token_transfers_job(tmpdir, start_block, end_block, batch_size, 
             lambda: build_web3(get_web3_provider(web3_provider_type, lambda file: read_resource(resource_group, file)))
         ),
         token_transfers_exporter=token_transfers_item_exporter(output_file),
-        token_transfers_v2_exporter=token_transfers_v2_item_exporter(output_file_token_transfer_v2),
         max_workers=5
     )
     job.run()
@@ -61,6 +59,3 @@ def test_export_token_transfers_job(tmpdir, start_block, end_block, batch_size, 
         read_resource(resource_group, 'expected_token_transfers.csv'), read_file(output_file)
     )
 
-    compare_lines_ignore_order(
-        read_resource(resource_group, 'expected_token_transfers_v2.csv'), read_file(output_file_token_transfer_v2)
-    )

--- a/tests/ethereumetl/job/test_export_token_transfers_job_v2.py
+++ b/tests/ethereumetl/job/test_export_token_transfers_job_v2.py
@@ -1,0 +1,37 @@
+import pytest
+from ethereumetl.web3_utils import build_web3
+
+import tests.resources
+from ethereumetl.jobs.export_token_transfers_job_v2 import ExportTokenTransfersJobV2
+from ethereumetl.jobs.exporters.token_transfers_v2_item_exporter import token_transfers_v2_item_exporter
+from ethereumetl.thread_local_proxy import ThreadLocalProxy
+from tests.ethereumetl.job.helpers import get_web3_provider
+from tests.helpers import compare_lines_ignore_order, read_file
+
+RESOURCE_GROUP = 'test_export_token_transfers_job'
+
+
+def read_resource(resource_group, file_name):
+    return tests.resources.read_resource([RESOURCE_GROUP, resource_group], file_name)
+
+
+@pytest.mark.parametrize("start_block,end_block,batch_size,resource_group,web3_provider_type", [
+    (483920, 483920, 1, 'block_with_transfers', 'mock')
+])
+def test_export_token_transfers_job_v2(tmpdir, start_block, end_block, batch_size, resource_group, web3_provider_type):
+    output_file = str(tmpdir.join('token_transfers.csv'))
+    output_file_token_transfer_v2 = str(tmpdir.join('token_transfers_v2.csv'))
+
+    job = ExportTokenTransfersJobV2(
+        start_block=start_block, end_block=end_block, batch_size=batch_size,
+        web3=ThreadLocalProxy(
+            lambda: build_web3(get_web3_provider(web3_provider_type, lambda file: read_resource(resource_group, file)))
+        ),
+        token_transfers_v2_exporter=token_transfers_v2_item_exporter(output_file_token_transfer_v2),
+        max_workers=5
+    )
+    job.run()
+
+    compare_lines_ignore_order(
+        read_resource(resource_group, 'expected_token_transfers_v2.csv'), read_file(output_file_token_transfer_v2)
+    )

--- a/tests/ethereumetl/job/test_extract_token_transfers_job_v2.py
+++ b/tests/ethereumetl/job/test_extract_token_transfers_job_v2.py
@@ -5,7 +5,7 @@ import pytest
 
 import tests.resources
 from ethereumetl.jobs.exporters.token_transfers_v2_item_exporter import token_transfers_v2_item_exporter
-from ethereumetl.jobs.extract_token_transfers_v2_job import ExtractTokenTransfersJobV2
+from ethereumetl.jobs.extract_token_transfers_v2_job import ExtractTokenTransfersV2Job
 from tests.helpers import compare_lines_ignore_order, read_file
 
 RESOURCE_GROUP = 'test_extract_token_transfers_job_v2'
@@ -23,7 +23,7 @@ def test_export_token_transfers_job(tmpdir, resource_group):
 
     logs_content = read_resource(resource_group, 'logs.csv')
     logs_csv_reader = csv.DictReader(io.StringIO(logs_content))
-    job = ExtractTokenTransfersJobV2(
+    job = ExtractTokenTransfersV2Job(
         logs_iterable=logs_csv_reader,
         batch_size=2,
         item_exporter=token_transfers_v2_item_exporter(output_file),

--- a/tests/ethereumetl/job/test_extract_token_transfers_job_v2.py
+++ b/tests/ethereumetl/job/test_extract_token_transfers_job_v2.py
@@ -1,0 +1,36 @@
+import csv
+import io
+
+import pytest
+
+import tests.resources
+from ethereumetl.jobs.exporters.token_transfers_v2_item_exporter import token_transfers_v2_item_exporter
+from ethereumetl.jobs.extract_token_transfers_v2_job import ExtractTokenTransfersJobV2
+from tests.helpers import compare_lines_ignore_order, read_file
+
+RESOURCE_GROUP = 'test_extract_token_transfers_job_v2'
+
+
+def read_resource(resource_group, file_name):
+    return tests.resources.read_resource([RESOURCE_GROUP, resource_group], file_name)
+
+
+@pytest.mark.parametrize('resource_group', [
+    'logs'
+])
+def test_export_token_transfers_job(tmpdir, resource_group):
+    output_file = str(tmpdir.join('token_transfers_v2.csv'))
+
+    logs_content = read_resource(resource_group, 'logs.csv')
+    logs_csv_reader = csv.DictReader(io.StringIO(logs_content))
+    job = ExtractTokenTransfersJobV2(
+        logs_iterable=logs_csv_reader,
+        batch_size=2,
+        item_exporter=token_transfers_v2_item_exporter(output_file),
+        max_workers=5
+    )
+    job.run()
+
+    compare_lines_ignore_order(
+        read_resource(resource_group, 'expected_token_transfers_v2.csv'), read_file(output_file)
+    )


### PR DESCRIPTION
`export` and `extract` jobs previously ran both token_transfer and token_transfer_v2 to same output essentially overwriting each other. This PR fixes that bug

## Test

run docker locally and pytests
<img width="718" alt="Screen Shot 2022-06-30 at 5 40 04 PM" src="https://user-images.githubusercontent.com/63827524/176800466-0c3da1f6-f6ec-488e-90e4-bc7f4dba3dfc.png">



